### PR TITLE
Removed reference to grundic/zabbix-disk-performance

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,43 +1,23 @@
-This package is currently maintained by Christoph Hueffelmann <chr@istoph.de> 2016
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
-It is designed for the software from: 
-http://www.zabbix.com/ 
+Copyright: 2020 Christoph Hueffelmann <chr@istoph.de>
+           2020 Sebastian Huebner <sebastian@hueb-ner.de>
+License: MIT
+ Copyright (c) 2020 Christoph Hueffelmann, Sebastian Huebner.
 
-Copyright: 
-
-  Copyright (c) 2013 
-  The MIT License (MIT) Grigory Chernyshev
-
-  Copyright (C) 2016 
-  Changes: Christoph Hueffelmann <chr@istoph.de> 
-
-  Quelle: https://github.com/grundic/zabbix-disk-performance
-
-License: 
-
-  Zabbix is an enterprise-class open source distributed monitoring solution. 
-  This program is free software; you can redistribute it and/or modify 
-  it under the terms of the GNU General Public License version 2 as 
-  published by the Free Software Foundation. 
-
-  On Debian GNU/Linux systems, the complete text of the GNU General 
-  Public License can be found in `/usr/share/common-licenses/GPL-2'.
-
-
-  The MIT License (MIT)
-  Permission is hereby granted, free of charge, to any person obtaining a copy of
-  this software and associated documentation files (the "Software"), to deal in
-  the Software without restriction, including without limitation the rights to
-  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-  the Software, and to permit persons to whom the Software is furnished to do so,
-  subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in all
-  copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ Permission is hereby granted, free of charge, to any person obtaining a copy of
+ this software and associated documentation files (the "Software"), to deal in
+ the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,9 +1,9 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
-Copyright: 2020 Christoph Hueffelmann <chr@istoph.de>
-           2020 Sebastian Huebner <sebastian@hueb-ner.de>
+Copyright: 2016, 2021 Christoph Hueffelmann <chr@istoph.de>
+           2016, 2021 Sebastian Huebner <sebastian@hueb-ner.de>
 License: MIT
- Copyright (c) 2020 Christoph Hueffelmann, Sebastian Huebner.
+ Copyright (c) 2021 Christoph Hueffelmann, Sebastian Huebner.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy of
  this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Since we don't use any code from this repository anymore (and didn't use it in the past anyway as far as I can see), I removed the notice of the project from our copyright.